### PR TITLE
Thread safety

### DIFF
--- a/src/knot/address.rs
+++ b/src/knot/address.rs
@@ -588,7 +588,7 @@ You find yourself in Addis Ababa, the capital of Ethiopia.
         let knots = read_knots_from_string(content).unwrap();
 
         let variables = &[("counter".to_string(), Variable::Int(0))]
-            .into_iter()
+            .iter()
             .cloned()
             .enumerate()
             .map(|(i, (name, var))| (name, VariableInfo::new(var, i)))

--- a/src/line/parse/choice.rs
+++ b/src/line/parse/choice.rs
@@ -214,7 +214,7 @@ pub(crate) mod tests {
         let choice = parse_choice_data("Choice line", &().into()).unwrap();
         let comparison = parse_internal_line("Choice line", &().into()).unwrap();
 
-        assert_eq!(*choice.selection_text.borrow(), comparison);
+        assert_eq!(*choice.selection_text.lock().unwrap(), comparison);
         assert_eq!(choice.display_text, comparison);
     }
 
@@ -222,7 +222,7 @@ pub(crate) mod tests {
     fn choices_can_be_parsed_with_alternatives_in_selection_text() {
         let choice = parse_choice_data("Hi! {One|Two}", &().into()).unwrap();
         assert_eq!(
-            *choice.selection_text.borrow(),
+            *choice.selection_text.lock().unwrap(),
             parse_internal_line("Hi! {One|Two}", &().into()).unwrap(),
         );
     }
@@ -231,7 +231,7 @@ pub(crate) mod tests {
     fn braces_with_backslash_are_not_conditions() {
         let choice = parse_choice_data("\\{One|Two}", &().into()).unwrap();
         assert_eq!(
-            *choice.selection_text.borrow(),
+            *choice.selection_text.lock().unwrap(),
             parse_internal_line("{One|Two}", &().into()).unwrap(),
         );
     }
@@ -240,7 +240,7 @@ pub(crate) mod tests {
     fn alternatives_can_be_within_brackets() {
         let choice = parse_choice_data("[{One|Two}]", &().into()).unwrap();
         assert_eq!(
-            *choice.selection_text.borrow(),
+            *choice.selection_text.lock().unwrap(),
             parse_internal_line("{One|Two}", &().into()).unwrap(),
         );
     }
@@ -250,7 +250,7 @@ pub(crate) mod tests {
         let choice = parse_choice_data("Selection[] plus display", &().into()).unwrap();
 
         assert_eq!(
-            *choice.selection_text.borrow(),
+            *choice.selection_text.lock().unwrap(),
             parse_internal_line("Selection", &().into()).unwrap()
         );
         assert_eq!(
@@ -261,7 +261,7 @@ pub(crate) mod tests {
         let choice = parse_choice_data("[Separate selection]And display", &().into()).unwrap();
 
         assert_eq!(
-            *choice.selection_text.borrow(),
+            *choice.selection_text.lock().unwrap(),
             parse_internal_line("Separate selection", &().into()).unwrap()
         );
         assert_eq!(

--- a/src/process/choice.rs
+++ b/src/process/choice.rs
@@ -8,7 +8,8 @@ use crate::{
     story::Choice,
 };
 
-use std::{cell::RefCell, rc::Rc};
+use std::sync::{Arc, Mutex};
+use std::ops::DerefMut;
 
 /// Prepare a list of choices to display to the user.
 ///
@@ -74,8 +75,8 @@ fn zip_choices_with_filter_values(
                 // If we are filtering the choice we do not want it's processed selection
                 // text to update their state. Instead, we clone the data and process that.
 
-                let independent_text = choice_data.selection_text.borrow().clone();
-                process_choice_text_and_tags(Rc::new(RefCell::new(independent_text)), data)
+                let independent_text = choice_data.selection_text.lock().unwrap().clone();
+                process_choice_text_and_tags(Arc::new(Mutex::new(independent_text)), data)
             }?;
 
             Ok((
@@ -92,12 +93,13 @@ fn zip_choices_with_filter_values(
 
 /// Process a line into a string and return it with its tags.
 fn process_choice_text_and_tags(
-    choice_line: Rc<RefCell<InternalLine>>,
+    choice_line: Arc<Mutex<InternalLine>>,
     data: &FollowData,
 ) -> Result<(String, Vec<String>), InklingError> {
     let mut data_buffer = Vec::new();
 
-    let mut line = choice_line.borrow_mut();
+    let mut line = choice_line.lock().unwrap();
+    let mut line = line.deref_mut();
 
     process_line(&mut line, &mut data_buffer, data).map_err(|err| InternalError::from(err))?;
 

--- a/tests/threading.rs
+++ b/tests/threading.rs
@@ -1,0 +1,35 @@
+use inkling::*;
+
+use std::thread;
+
+#[test]
+fn threading() {
+    let content = "
+
+Mont Blanc was a world-renowned mountain guide.
+He befriended thousands of climbers and children sightseeing in Switzerland.
+
+-> DONE
+
+";
+
+    let mut story = read_story_from_string(content).unwrap();
+
+
+    let handle = thread::spawn(move || {
+        story.start().unwrap();
+        story
+    });
+
+
+    let mut story = handle.join().unwrap();
+    let mut line_buffer = Vec::new();
+
+    match story.resume(&mut line_buffer) {
+        Ok(Prompt::Done) => {
+            assert_eq!(line_buffer.len(), 2);
+        }
+        _ => panic!("error while reading a flat story from string"),
+    }
+}
+


### PR DESCRIPTION
I switched Rc's to Arc's and RefCell's to Mutex's so that everything can be moved to a thread.
I also switched one instance of into_iter() to iter() to please the new compiler's warning.

**Caveat**: this comes with trade-offs that this project may not want. Mutexes can deadlock if not treated will (see the implementation of PartialEq for one instance where I had to already get around that). 

Also, Arc's are more expensive than Rc's.

I fully understand if this project does not want these things, but if so, enjoy! :)