### PR TITLE
Random alternative sequences

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,13 @@ keywords = ["ink", "dialog", "dialogue", "markup", "game"]
 
 [features]
 serde_support = ["serde/derive"]
+shuffle_sequences = ["rand", "rand_chacha"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
+rand = { version = "0.7", optional = true }
+rand_chacha = { version = "0.2", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
+serde_test = "1.0"

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Currently and likely for the foreseeable future the feature set is very limited 
 *   Knots, stitches, glue and diverts, ie. basic story structure
 *   Choices, of sticky and non-sticky kinds, plus fallback choices
 *   Nesting choices and gather points
-*   Line text alternative sequences (sequences, cycle, once-only) and conditions
+*   Line text alternative sequences (sequences, cycle, once-only, shuffle) and conditions
 *   Conditionals for displaying text and choices to user
 *   Tagging of lines and choices
 *   Variables in choices, conditions and text

--- a/src/follow.rs
+++ b/src/follow.rs
@@ -1,6 +1,11 @@
 //! Results and data that is used or encountered when following, or walking through, a story.
 
-use crate::{error::InklingError, knot::Address, line::InternalChoice, story::types::VariableSet};
+use crate::{
+    error::InklingError,
+    knot::Address,
+    line::InternalChoice,
+    story::{rng::StoryRng, types::VariableSet},
+};
 
 #[cfg(feature = "serde_support")]
 use serde::{Deserialize, Serialize};
@@ -43,7 +48,7 @@ impl ChoiceInfo {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 #[cfg_attr(feature = "serde_support", derive(Deserialize, Serialize))]
 /// Data used during a follow through knots and nodes.
 pub struct FollowData {
@@ -51,6 +56,8 @@ pub struct FollowData {
     pub knot_visit_counts: HashMap<String, HashMap<String, u32>>,
     /// Global variables in story.
     pub variables: VariableSet,
+    /// Random number generator
+    pub rng: StoryRng,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/knot/stitch.rs
+++ b/src/knot/stitch.rs
@@ -210,6 +210,7 @@ mod tests {
         error::parse::line::LineError,
         knot::{get_num_visited, Address},
         line::{InternalLine, ParsedLineKind},
+        story::rng::StoryRng,
     };
 
     use std::str::FromStr;
@@ -245,6 +246,7 @@ mod tests {
         FollowData {
             knot_visit_counts,
             variables: HashMap::new(),
+            rng: StoryRng::default(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,8 +121,8 @@
 //! *   Structure:  Knots, stitches, nested branching choices, gathers, diverts,
 //!                 tags for knots and story
 //! *   Choices:    Non-sticky, sticky, fallback, line variations, conditions
-//! *   Lines:      Plain text, diverts, tags, conditions, alternative sequences (all
-//!                 except shuffle)
+//! *   Lines:      Plain text, diverts, tags, conditions, alternative sequences
+//!                 (enable shuffle sequences with the `shuffle_sequences` feature)
 //! *   Conditions: Nested, `and`/`or` linking, can check against variables
 //! *   Reading:    Address validation for diverts and conditions. Conditions and expressions
 //!                 are validated after parsing the story.
@@ -149,6 +149,15 @@
 //! and loading.
 //!
 //! For more information about `serde` see their [website](https://serde.rs/).
+//!
+//! # Shuffle variation sequences
+//! Proper shuffle sequences using the `{~One|Two|Three}` syntax are enabled with
+//! the `shuffle_sequences` feature. This adds `rand` and `rand_chacha` as dependencies.
+//! If combined with `serde_support`, the random number generator state will be
+//! properly saved and restored along with the rest of the data.
+//!
+//! If `shuffle_sequences` is not enabled, all shuffle sequences are replaced by
+//! cycling sequences. No warning is given if this occurs.
 //!
 //! # Contributions
 //! I am a complete novice at designing frameworks which will fit into larger schemes.

--- a/src/line/alternative.rs
+++ b/src/line/alternative.rs
@@ -92,6 +92,11 @@ pub enum AlternativeKind {
     /// A train traveling to its destination `[Frankfurt, Mannheim, Heidelberg]` will print
     /// each destination, then `Heidelberg` forever after reaching the city.
     Sequence,
+    /// Shuffles the active list, then goes through it and cycles with a new shuffle at the end.
+    /// 
+    /// # Example
+    /// A set of three cards `[One, Two, Three]` will be shuffled then dealt one by one. Once
+    /// the set is empty, the deck is reshuffled.
     Shuffle,
 }
 

--- a/src/line/alternative.rs
+++ b/src/line/alternative.rs
@@ -37,6 +37,7 @@ pub struct Alternative {
 
 impl Alternative {
     #[allow(unused_variables)] // `data` only used when the `shuffle_sequences` feature is enabled
+    /// Get the next item index in the alternative sequence.
     pub fn get_next_index(&mut self, data: &mut FollowData) -> Option<usize> {
         match self.kind {
             AlternativeKind::OnceOnly => self.active_inds.pop(),
@@ -55,7 +56,7 @@ impl Alternative {
                 }
 
                 #[cfg(feature = "shuffle_sequences")]
-                if self.active_inds.len() == self.items.len() {
+                if self.is_first_item() {
                     self.active_inds.shuffle(&mut data.rng.gen);
                 }
 
@@ -64,6 +65,13 @@ impl Alternative {
         }
     }
 
+    #[allow(dead_code)]
+    /// Return whether or not we are at the first item in the sequence.
+    fn is_first_item(&self) -> bool {
+        self.active_inds.len() == self.items.len()
+    }
+
+    /// Reset the active list by remaking the index list and reversing it.
     fn reset_active_list(&mut self) {
         self.active_inds = (0..self.items.len()).rev().collect();
     }
@@ -93,7 +101,7 @@ pub enum AlternativeKind {
     /// each destination, then `Heidelberg` forever after reaching the city.
     Sequence,
     /// Shuffles the active list, then goes through it and cycles with a new shuffle at the end.
-    /// 
+    ///
     /// # Example
     /// A set of three cards `[One, Two, Three]` will be shuffled then dealt one by one. Once
     /// the set is empty, the deck is reshuffled.

--- a/src/line/expression.rs
+++ b/src/line/expression.rs
@@ -227,7 +227,10 @@ impl ValidateContent for Operand {
 mod tests {
     use super::*;
 
-    use crate::{knot::Address, story::types::VariableInfo};
+    use crate::{
+        knot::Address,
+        story::{rng::StoryRng, types::VariableInfo},
+    };
 
     use std::collections::HashMap;
 
@@ -274,6 +277,7 @@ mod tests {
         FollowData {
             knot_visit_counts,
             variables,
+            rng: StoryRng::default(),
         }
     }
 

--- a/src/line/parse/alternative.rs
+++ b/src/line/parse/alternative.rs
@@ -42,13 +42,7 @@ fn get_sequence_kind(content: &str) -> AlternativeKind {
     } else if content.starts_with(ONCE_ONLY_MARKER) {
         AlternativeKind::OnceOnly
     } else if content.starts_with(SHUFFLE_MARKER) {
-        eprintln!(
-            "WARNING: Shuffle sequences are not yet implemented. Creating a `Cycle` sequence. \
-             (line was: '{}')",
-            content
-        );
-
-        AlternativeKind::Cycle
+        AlternativeKind::Shuffle
     } else {
         AlternativeKind::Sequence
     }
@@ -104,6 +98,16 @@ mod tests {
     }
 
     #[test]
+    fn list_of_strings_beginning_with_tilde_mark_gives_shuffle() {
+        let text = "~One|Two|Three";
+
+        match &parse_alternative(text).unwrap().kind {
+            AlternativeKind::Shuffle => (),
+            kind => panic!("expected `AlternativeKind::Shuffle` but got {:?}", kind),
+        }
+    }
+
+    #[test]
     fn whitespace_is_trimmed_from_the_beginning() {
         let text = " &One|Two|Three";
         let mut alternative = parse_alternative(text).unwrap();
@@ -119,5 +123,10 @@ mod tests {
     #[test]
     fn empty_strings_do_not_fail() {
         assert!(parse_alternative("").is_ok());
+    }
+
+    #[test]
+    fn only_marker_does_not_fail() {
+        assert!(parse_alternative("~").is_ok());
     }
 }

--- a/src/line/parse/expression.rs
+++ b/src/line/parse/expression.rs
@@ -249,7 +249,7 @@ mod tests {
         follow::FollowData,
         knot::Address,
         line::{evaluate_expression, Variable},
-        story::types::VariableInfo,
+        story::{rng::StoryRng, types::VariableInfo},
     };
 
     use std::collections::HashMap;
@@ -275,6 +275,7 @@ mod tests {
         FollowData {
             knot_visit_counts,
             variables,
+            rng: StoryRng::default(),
         }
     }
 

--- a/src/line/variable.rs
+++ b/src/line/variable.rs
@@ -717,7 +717,7 @@ impl ValidateContent for Variable {
 mod tests {
     use super::*;
 
-    use crate::story::types::VariableInfo;
+    use crate::story::{rng::StoryRng, types::VariableInfo};
 
     use std::collections::HashMap;
 
@@ -742,6 +742,7 @@ mod tests {
         FollowData {
             knot_visit_counts,
             variables,
+            rng: StoryRng::default(),
         }
     }
 

--- a/src/node/follow.rs
+++ b/src/node/follow.rs
@@ -323,6 +323,7 @@ mod tests {
         knot::{get_num_visited, Address},
         line::{InternalChoice, LineChunkBuilder},
         node::builders::{BranchBuilder, BranchingPointBuilder, RootNodeBuilder},
+        story::rng::StoryRng,
     };
 
     use std::collections::HashMap;
@@ -339,6 +340,7 @@ mod tests {
         FollowData {
             knot_visit_counts,
             variables: HashMap::new(),
+            rng: StoryRng::default(),
         }
     }
 

--- a/src/process/condition.rs
+++ b/src/process/condition.rs
@@ -59,7 +59,7 @@ mod tests {
             expression::{Expression, Operand},
             ConditionBuilder,
         },
-        story::types::VariableInfo,
+        story::{rng::StoryRng, types::VariableInfo},
     };
 
     use std::collections::HashMap;
@@ -85,6 +85,7 @@ mod tests {
         FollowData {
             knot_visit_counts,
             variables,
+            rng: StoryRng::default(),
         }
     }
 

--- a/src/process/line.rs
+++ b/src/process/line.rs
@@ -11,7 +11,7 @@ use crate::{
 pub fn process_line(
     line: &mut InternalLine,
     buffer: &mut LineDataBuffer,
-    data: &FollowData,
+    data: &mut FollowData,
 ) -> Result<EncounteredEvent, ProcessError> {
     let mut text_buffer = String::new();
 
@@ -37,7 +37,7 @@ pub fn process_line(
 fn process_chunk(
     chunk: &mut LineChunk,
     buffer: &mut String,
-    data: &FollowData,
+    data: &mut FollowData,
 ) -> Result<EncounteredEvent, ProcessError> {
     let items = match &chunk.condition {
         Some(ref condition) => {
@@ -65,7 +65,7 @@ fn process_chunk(
 fn process_content(
     item: &mut Content,
     buffer: &mut String,
-    data: &FollowData,
+    data: &mut FollowData,
 ) -> Result<EncounteredEvent, ProcessError> {
     match item {
         Content::Alternative(alternative) => process_alternative(alternative, buffer, data),
@@ -91,7 +91,7 @@ fn process_content(
 fn process_alternative(
     alternative: &mut Alternative,
     buffer: &mut String,
-    data: &FollowData,
+    data: &mut FollowData,
 ) -> Result<EncounteredEvent, ProcessError> {
     let num_items = alternative.items.len();
 
@@ -154,29 +154,30 @@ pub mod tests {
             expression::Operand, parse::parse_internal_line, AlternativeBuilder, ConditionBuilder,
             ConditionKind, Expression, LineChunkBuilder, Variable,
         },
+        story::rng::StoryRng,
     };
 
     use std::collections::HashMap;
 
     pub fn get_processed_alternative(alternative: &mut Alternative) -> String {
         let mut buffer = String::new();
-        let data = mock_data_with_single_stitch("", "", 0);
+        let mut data = mock_data_with_single_stitch("", "", 0);
 
-        process_alternative(alternative, &mut buffer, &data).unwrap();
+        process_alternative(alternative, &mut buffer, &mut data).unwrap();
 
         buffer
     }
 
     pub fn get_processed_chunk(chunk: &mut LineChunk) -> String {
         let mut buffer = String::new();
-        let data = mock_data_with_single_stitch("", "", 0);
+        let mut data = mock_data_with_single_stitch("", "", 0);
 
-        process_chunk(chunk, &mut buffer, &data).unwrap();
+        process_chunk(chunk, &mut buffer, &mut data).unwrap();
 
         buffer
     }
 
-    fn mock_data_with_single_stitch(knot: &str, stitch: &str, num_visited: u32) -> FollowData {
+    pub fn mock_data_with_single_stitch(knot: &str, stitch: &str, num_visited: u32) -> FollowData {
         let mut stitch_count = HashMap::new();
         stitch_count.insert(stitch.to_string(), num_visited);
 
@@ -186,6 +187,7 @@ pub mod tests {
         FollowData {
             knot_visit_counts,
             variables: HashMap::new(),
+            rng: StoryRng::default(),
         }
     }
 
@@ -196,9 +198,9 @@ pub mod tests {
         line.glue_end = true;
 
         let mut buffer = Vec::new();
-        let data = mock_data_with_single_stitch("", "", 0);
+        let mut data = mock_data_with_single_stitch("", "", 0);
 
-        process_line(&mut line, &mut buffer, &data).unwrap();
+        process_line(&mut line, &mut buffer, &mut data).unwrap();
 
         let result = &buffer[0];
         assert!(result.glue_begin);
@@ -211,9 +213,9 @@ pub mod tests {
         line.tags = vec!["tag 1".to_string(), "tag 2".to_string()];
 
         let mut buffer = Vec::new();
-        let data = mock_data_with_single_stitch("", "", 0);
+        let mut data = mock_data_with_single_stitch("", "", 0);
 
-        process_line(&mut line, &mut buffer, &data).unwrap();
+        process_line(&mut line, &mut buffer, &mut data).unwrap();
 
         let result = &buffer[0];
         assert_eq!(result.tags, line.tags);
@@ -222,10 +224,10 @@ pub mod tests {
     #[test]
     fn pure_text_line_processes_into_the_contained_string() {
         let mut buffer = String::new();
-        let data = mock_data_with_single_stitch("", "", 0);
+        let mut data = mock_data_with_single_stitch("", "", 0);
 
         let mut item = Content::Text("Hello, World!".to_string());
-        process_content(&mut item, &mut buffer, &data).unwrap();
+        process_content(&mut item, &mut buffer, &mut data).unwrap();
 
         assert_eq!(&buffer, "Hello, World!");
     }
@@ -233,7 +235,7 @@ pub mod tests {
     #[test]
     fn expression_evaluates_into_variable_and_prints_it() {
         let mut buffer = String::new();
-        let data = mock_data_with_single_stitch("", "", 0);
+        let mut data = mock_data_with_single_stitch("", "", 0);
 
         let expression = Expression {
             head: Operand::Variable(5.into()),
@@ -242,7 +244,7 @@ pub mod tests {
 
         let mut item = Content::Expression(expression);
 
-        process_content(&mut item, &mut buffer, &data).unwrap();
+        process_content(&mut item, &mut buffer, &mut data).unwrap();
 
         assert_eq!(&buffer, "5");
     }
@@ -250,7 +252,7 @@ pub mod tests {
     #[test]
     fn divert_variable_yields_error() {
         let mut buffer = String::new();
-        let data = mock_data_with_single_stitch("", "", 0);
+        let mut data = mock_data_with_single_stitch("", "", 0);
 
         let variable = Variable::Divert(Address::End);
 
@@ -261,16 +263,16 @@ pub mod tests {
 
         let mut item = Content::Expression(expression);
 
-        assert!(process_content(&mut item, &mut buffer, &data).is_err());
+        assert!(process_content(&mut item, &mut buffer, &mut data).is_err());
     }
 
     #[test]
     fn empty_content_processes_into_single_white_space() {
         let mut buffer = String::new();
-        let data = mock_data_with_single_stitch("", "", 0);
+        let mut data = mock_data_with_single_stitch("", "", 0);
 
         let mut item = Content::Empty;
-        process_content(&mut item, &mut buffer, &data).unwrap();
+        process_content(&mut item, &mut buffer, &mut data).unwrap();
 
         assert_eq!(&buffer, " ");
     }
@@ -279,10 +281,10 @@ pub mod tests {
     fn line_with_text_processes_into_that_text() {
         let content = "Text string.";
         let mut buffer = String::new();
-        let data = mock_data_with_single_stitch("", "", 0);
+        let mut data = mock_data_with_single_stitch("", "", 0);
 
         let mut line = LineChunkBuilder::from_string(content).build();
-        process_chunk(&mut line, &mut buffer, &data).unwrap();
+        process_chunk(&mut line, &mut buffer, &mut data).unwrap();
 
         assert_eq!(&buffer, content);
     }
@@ -290,14 +292,14 @@ pub mod tests {
     #[test]
     fn chunks_with_several_text_items_stitch_them_with_no_whitespace() {
         let mut buffer = String::new();
-        let data = mock_data_with_single_stitch("", "", 0);
+        let mut data = mock_data_with_single_stitch("", "", 0);
 
         let mut chunk = LineChunkBuilder::new()
             .with_text("Line 1")
             .with_text("Line 2")
             .build();
 
-        process_chunk(&mut chunk, &mut buffer, &data).unwrap();
+        process_chunk(&mut chunk, &mut buffer, &mut data).unwrap();
 
         assert_eq!(&buffer, "Line 1Line 2");
     }
@@ -314,15 +316,15 @@ pub mod tests {
         };
 
         let mut buffer = String::new();
-        let data = mock_data_with_single_stitch("", "", 0);
-        process_chunk(&mut chunk, &mut buffer, &data).unwrap();
+        let mut data = mock_data_with_single_stitch("", "", 0);
+        process_chunk(&mut chunk, &mut buffer, &mut data).unwrap();
 
         assert_eq!(&buffer, "Displayed if true.");
 
         chunk.condition.replace(false_condition);
 
         buffer.clear();
-        process_chunk(&mut chunk, &mut buffer, &data).unwrap();
+        process_chunk(&mut chunk, &mut buffer, &mut data).unwrap();
         assert_eq!(&buffer, "");
     }
 
@@ -338,15 +340,15 @@ pub mod tests {
         };
 
         let mut buffer = String::new();
-        let data = mock_data_with_single_stitch("", "", 0);
-        process_chunk(&mut chunk, &mut buffer, &data).unwrap();
+        let mut data = mock_data_with_single_stitch("", "", 0);
+        process_chunk(&mut chunk, &mut buffer, &mut data).unwrap();
 
         assert_eq!(&buffer, "Displayed if true.");
 
         chunk.condition.replace(false_condition);
 
         buffer.clear();
-        process_chunk(&mut chunk, &mut buffer, &data).unwrap();
+        process_chunk(&mut chunk, &mut buffer, &mut data).unwrap();
         assert_eq!(&buffer, "Displayed if false.");
     }
 
@@ -359,8 +361,8 @@ pub mod tests {
         };
 
         let mut buffer = String::new();
-        let data = mock_data_with_single_stitch("", "", 0);
-        process_chunk(&mut chunk, &mut buffer, &data).unwrap();
+        let mut data = mock_data_with_single_stitch("", "", 0);
+        process_chunk(&mut chunk, &mut buffer, &mut data).unwrap();
 
         assert_eq!(&buffer, "Displayed if true.");
     }
@@ -368,7 +370,7 @@ pub mod tests {
     #[test]
     fn lines_shortcut_if_proper_diverts_are_encountered() {
         let mut buffer = String::new();
-        let data = mock_data_with_single_stitch("", "", 0);
+        let mut data = mock_data_with_single_stitch("", "", 0);
 
         let mut chunk = LineChunkBuilder::new()
             .with_text("Line 1")
@@ -377,7 +379,7 @@ pub mod tests {
             .build();
 
         assert_eq!(
-            process_chunk(&mut chunk, &mut buffer, &data).unwrap(),
+            process_chunk(&mut chunk, &mut buffer, &mut data).unwrap(),
             EncounteredEvent::Divert(Address::Raw("divert".to_string()))
         );
 
@@ -392,17 +394,17 @@ pub mod tests {
             .build();
 
         let mut buffer = String::new();
-        let data = mock_data_with_single_stitch("", "", 0);
+        let mut data = mock_data_with_single_stitch("", "", 0);
 
-        process_alternative(&mut sequence, &mut buffer, &data).unwrap();
+        process_alternative(&mut sequence, &mut buffer, &mut data).unwrap();
         assert_eq!(&buffer, "Line 1");
         buffer.clear();
 
-        process_alternative(&mut sequence, &mut buffer, &data).unwrap();
+        process_alternative(&mut sequence, &mut buffer, &mut data).unwrap();
         assert_eq!(&buffer, "Line 2");
         buffer.clear();
 
-        process_alternative(&mut sequence, &mut buffer, &data).unwrap();
+        process_alternative(&mut sequence, &mut buffer, &mut data).unwrap();
         assert_eq!(&buffer, "Line 2");
         buffer.clear();
     }
@@ -415,17 +417,17 @@ pub mod tests {
             .build();
 
         let mut buffer = String::new();
-        let data = mock_data_with_single_stitch("", "", 0);
+        let mut data = mock_data_with_single_stitch("", "", 0);
 
-        process_alternative(&mut once_only, &mut buffer, &data).unwrap();
+        process_alternative(&mut once_only, &mut buffer, &mut data).unwrap();
         assert_eq!(&buffer, "Line 1");
         buffer.clear();
 
-        process_alternative(&mut once_only, &mut buffer, &data).unwrap();
+        process_alternative(&mut once_only, &mut buffer, &mut data).unwrap();
         assert_eq!(&buffer, "Line 2");
         buffer.clear();
 
-        process_alternative(&mut once_only, &mut buffer, &data).unwrap();
+        process_alternative(&mut once_only, &mut buffer, &mut data).unwrap();
         assert!(buffer.is_empty());
     }
 
@@ -437,17 +439,20 @@ pub mod tests {
             .build();
 
         let mut buffer = String::new();
-        let data = mock_data_with_single_stitch("", "", 0);
+        let mut data = mock_data_with_single_stitch("", "", 0);
 
-        process_alternative(&mut cycle, &mut buffer, &data).unwrap();
+        process_alternative(&mut cycle, &mut buffer, &mut data).unwrap();
         assert_eq!(&buffer, "Line 1");
         buffer.clear();
 
-        process_alternative(&mut cycle, &mut buffer, &data).unwrap();
+        process_alternative(&mut cycle, &mut buffer, &mut data).unwrap();
         assert_eq!(&buffer, "Line 2");
         buffer.clear();
 
-        process_alternative(&mut cycle, &mut buffer, &data).unwrap();
+        process_alternative(&mut cycle, &mut buffer, &mut data).unwrap();
+        assert_eq!(&buffer, "Line 1");
+        buffer.clear();
+    }
         assert_eq!(&buffer, "Line 1");
         buffer.clear();
     }
@@ -461,23 +466,23 @@ pub mod tests {
             .build();
 
         let mut buffer = String::new();
-        let data = mock_data_with_single_stitch("", "", 0);
+        let mut data = mock_data_with_single_stitch("", "", 0);
 
         assert_eq!(
-            process_alternative(&mut alternative, &mut buffer, &data).unwrap(),
+            process_alternative(&mut alternative, &mut buffer, &mut data).unwrap(),
             EncounteredEvent::Done
         );
         assert_eq!(&buffer, "Line 1");
         buffer.clear();
 
         assert_eq!(
-            process_alternative(&mut alternative, &mut buffer, &data).unwrap(),
+            process_alternative(&mut alternative, &mut buffer, &mut data).unwrap(),
             EncounteredEvent::Divert(Address::Raw("divert".to_string()))
         );
         buffer.clear();
 
         assert_eq!(
-            process_alternative(&mut alternative, &mut buffer, &data).unwrap(),
+            process_alternative(&mut alternative, &mut buffer, &mut data).unwrap(),
             EncounteredEvent::Done
         );
         assert_eq!(&buffer, "Line 2");
@@ -502,10 +507,10 @@ pub mod tests {
             .build();
 
         let mut buffer = String::new();
-        let data = mock_data_with_single_stitch("", "", 0);
+        let mut data = mock_data_with_single_stitch("", "", 0);
 
         assert_eq!(
-            process_chunk(&mut line, &mut buffer, &data).unwrap(),
+            process_chunk(&mut line, &mut buffer, &mut data).unwrap(),
             EncounteredEvent::Done
         );
 
@@ -513,7 +518,7 @@ pub mod tests {
         buffer.clear();
 
         assert_eq!(
-            process_chunk(&mut line, &mut buffer, &data).unwrap(),
+            process_chunk(&mut line, &mut buffer, &mut data).unwrap(),
             EncounteredEvent::Divert(Address::Raw("divert".to_string()))
         );
 
@@ -521,7 +526,7 @@ pub mod tests {
         buffer.clear();
 
         assert_eq!(
-            process_chunk(&mut line, &mut buffer, &data).unwrap(),
+            process_chunk(&mut line, &mut buffer, &mut data).unwrap(),
             EncounteredEvent::Done
         );
 

--- a/src/story/mod.rs
+++ b/src/story/mod.rs
@@ -12,6 +12,7 @@
 //! presented to the user, or validating the content of the story as it is being accessed.
 
 pub(crate) mod parse;
+pub(crate) mod rng;
 mod story;
 pub(crate) mod types;
 mod utils;

--- a/src/story/rng.rs
+++ b/src/story/rng.rs
@@ -21,7 +21,7 @@ mod feature_wrapper {
     use serde::{Deserialize, Serialize};
 
     #[cfg_attr(feature = "serde_support", derive(Deserialize, Serialize))]
-    #[derive(Debug, Default)]
+    #[derive(Clone, Debug, Default)]
     /// Random number generator for the [`Story`][crate::story::Story].
     ///
     /// If the `shuffle_sequences` is not enabled this is a dummy struct which will
@@ -44,7 +44,7 @@ mod feature_wrapper {
         ser::{Serialize, SerializeStruct, Serializer},
     };
 
-    #[derive(Debug)]
+    #[derive(Clone, Debug)]
     /// Random number generator for the [`Story`][crate::story::Story].
     ///
     /// We use `ChaChaRng` due to it being seedable and with the ability to get and set

--- a/src/story/rng.rs
+++ b/src/story/rng.rs
@@ -1,0 +1,281 @@
+//! Wrapper around a random number generator.
+//!
+//! The wrapper is needed because we only have a generator if the `shuffle_sequences`
+//! feature is enabled. If it is not enabled, we do not have the generator. Thus,
+//! we wrap the generator (if needed) in the `StoryRng` struct, which is empty
+//! if `shuffle_sequences` is not enabled.
+//!
+//! This means that regardless of whether or not we need the generator, we have
+//! and object that we can pass through the system and won't have to make a lot
+//! of conditionals in the rest of the code. Only when the generator will be needed,
+//! such as for generating the alternative shuffle sequences.
+
+// For scope simplicity we create a private modules depending on whether or not
+// the random generator will be needed. We then export the `StoryRng` object
+// from the module.
+pub use feature_wrapper::StoryRng;
+
+#[cfg(not(feature = "shuffle_sequences"))]
+mod feature_wrapper {
+    #[cfg(feature = "serde_support")]
+    use serde::{Deserialize, Serialize};
+
+    #[cfg_attr(feature = "serde_support", derive(Deserialize, Serialize))]
+    #[derive(Debug, Default)]
+    /// Random number generator for the [`Story`][crate::story::Story].
+    ///
+    /// If the `shuffle_sequences` is not enabled this is a dummy struct which will
+    /// not be used when moving through the story. Otherwise, it holds the generator
+    /// and complementary information for generating numbers.
+    ///
+    /// If you are reading this text, the `shuffle_sequences` feature is **not**
+    /// currently enabled.
+    pub struct StoryRng;
+}
+
+#[cfg(feature = "shuffle_sequences")]
+mod feature_wrapper {
+    use rand::{RngCore, SeedableRng};
+    use rand_chacha::ChaCha8Rng;
+
+    #[cfg(feature = "serde_support")]
+    use serde::{
+        de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor},
+        ser::{Serialize, SerializeStruct, Serializer},
+    };
+
+    #[derive(Debug)]
+    /// Random number generator for the [`Story`][crate::story::Story].
+    ///
+    /// We use `ChaChaRng` due to it being seedable and with the ability to get and set
+    /// the word position. This is necessary to restore the state when de/serializing.
+    ///
+    /// If the `serde_support` feature is enabled, we manually derived `Deserialize`
+    /// and `Serialize` below. This is due to the generator itself not having either
+    /// derived.
+    pub struct StoryRng {
+        /// Random number generator.
+        gen: ChaCha8Rng,
+        /// Seed for the generator.
+        seed: u64,
+    }
+
+    impl Default for StoryRng {
+        fn default() -> Self {
+            let seed = ChaCha8Rng::from_entropy().next_u64();
+            StoryRng::with_seed(seed)
+        }
+    }
+
+    impl StoryRng {
+        /// Initiate the random number generator with a seed.
+        fn with_seed(seed: u64) -> Self {
+            let mut gen = ChaCha8Rng::seed_from_u64(seed);
+
+            // `get_word_pos()` will panic unless we set the stream to 0
+            gen.set_word_pos(0);
+
+            StoryRng { gen, seed }
+        }
+
+        #[cfg(feature = "serde_support")]
+        /// Initiate the random number generator with a seed and word position.
+        fn with_seed_and_position(seed: u64, position: u128) -> Self {
+            let mut rng = Self::with_seed(seed);
+            rng.gen.set_word_pos(position);
+
+            rng
+        }
+    }
+
+    #[cfg(feature = "serde_support")]
+    impl Serialize for StoryRng {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            // The word position for `ChaCha8Rng` is u128 but `serde` can only serialize
+            // up to u64. Ensure that we de/serialize as that.
+            let position = self.gen.get_word_pos() as u64;
+
+            let mut state = serializer.serialize_struct("StoryRng", 2)?;
+            state.skip_field("gen")?;
+            state.serialize_field("seed", &self.seed)?;
+            state.serialize_field("position", &position)?;
+            state.end()
+        }
+    }
+
+    #[cfg(feature = "serde_support")]
+    impl<'de> Deserialize<'de> for StoryRng {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            use std::fmt;
+
+            enum Field {
+                Seed,
+                Position,
+            };
+
+            impl<'de> Deserialize<'de> for Field {
+                fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+                where
+                    D: Deserializer<'de>,
+                {
+                    struct FieldVisitor;
+
+                    impl<'de> Visitor<'de> for FieldVisitor {
+                        type Value = Field;
+
+                        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                            formatter.write_str("`seed` or `position`")
+                        }
+
+                        fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                        where
+                            E: de::Error,
+                        {
+                            match value {
+                                "seed" => Ok(Field::Seed),
+                                "position" => Ok(Field::Position),
+                                _ => Err(de::Error::unknown_field(value, FIELDS)),
+                            }
+                        }
+                    }
+
+                    deserializer.deserialize_identifier(FieldVisitor)
+                }
+            }
+
+            struct StoryRngVisitor;
+
+            impl<'de> Visitor<'de> for StoryRngVisitor {
+                type Value = StoryRng;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("struct StoryRng")
+                }
+
+                fn visit_seq<V>(self, mut seq: V) -> Result<StoryRng, V::Error>
+                where
+                    V: SeqAccess<'de>,
+                {
+                    let seed = seq
+                        .next_element()?
+                        .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+
+                    // The word position for `ChaCha8Rng` is u128 but `serde` can only serialize
+                    // up to u64. Ensure that we de/serialize as that.
+                    let position: u64 = seq
+                        .next_element()?
+                        .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+
+                    Ok(StoryRng::with_seed_and_position(seed, position as u128))
+                }
+
+                fn visit_map<V>(self, mut map: V) -> Result<StoryRng, V::Error>
+                where
+                    V: MapAccess<'de>,
+                {
+                    let mut seed = None;
+                    let mut position = None;
+
+                    while let Some(key) = map.next_key()? {
+                        match key {
+                            Field::Seed => {
+                                if seed.is_some() {
+                                    return Err(de::Error::duplicate_field("seed"));
+                                }
+                                seed = Some(map.next_value()?);
+                            }
+                            Field::Position => {
+                                if position.is_some() {
+                                    return Err(de::Error::duplicate_field("position"));
+                                }
+                                position = Some(map.next_value()?);
+                            }
+                        }
+                    }
+
+                    let seed = seed.ok_or_else(|| de::Error::missing_field("seed"))?;
+
+                    // The word position for `ChaCha8Rng` is u128 but `serde` can only serialize
+                    // up to u64. Ensure that we de/serialize as that.
+                    let position: u64 =
+                        position.ok_or_else(|| de::Error::missing_field("position"))?;
+
+                    Ok(StoryRng::with_seed_and_position(seed, position as u128))
+                }
+            }
+
+            const FIELDS: &'static [&'static str] = &["seed", "position"];
+            deserializer.deserialize_struct("StoryRng", FIELDS, StoryRngVisitor)
+        }
+    }
+
+    #[cfg(all(test, feature = "serde_support"))]
+    mod tests {
+        use super::*;
+        use serde_test::*;
+
+        // Implementation for `PartialEq` to satisfy bounds on `serde_test` functions
+        impl PartialEq for StoryRng {
+            fn eq(&self, other: &Self) -> bool {
+                self.seed == other.seed && self.gen.get_word_pos() == other.gen.get_word_pos()
+            }
+        }
+
+        #[test]
+        fn story_rng_serializes_with_seed() {
+            let seed = 30;
+            let rng = StoryRng::with_seed(seed);
+
+            let position = rng.gen.get_word_pos() as u64;
+
+            assert_tokens(
+                &rng,
+                &[
+                    Token::Struct {
+                        name: "StoryRng",
+                        len: 2,
+                    },
+                    Token::Str("seed"),
+                    Token::U64(seed),
+                    Token::Str("position"),
+                    Token::U64(position),
+                    Token::StructEnd,
+                ],
+            );
+        }
+
+        #[test]
+        fn story_rng_serializes_with_correct_word_position() {
+            let seed = 30;
+            let mut rng = StoryRng::with_seed(seed);
+
+            let mut buffer = vec![0; 64];
+            rng.gen.fill_bytes(&mut buffer);
+
+            // Get and sanity check current position, it should not be zero right now
+            let position = rng.gen.get_word_pos() as u64;
+            assert!(position > 0);
+
+            assert_tokens(
+                &rng,
+                &[
+                    Token::Struct {
+                        name: "StoryRng",
+                        len: 2,
+                    },
+                    Token::Str("seed"),
+                    Token::U64(seed),
+                    Token::Str("position"),
+                    Token::U64(position),
+                    Token::StructEnd,
+                ],
+            );
+        }
+    }
+}

--- a/src/story/rng.rs
+++ b/src/story/rng.rs
@@ -55,7 +55,7 @@ mod feature_wrapper {
     /// derived.
     pub struct StoryRng {
         /// Random number generator.
-        gen: ChaCha8Rng,
+        pub gen: ChaCha8Rng,
         /// Seed for the generator.
         seed: u64,
     }

--- a/src/story/story.rs
+++ b/src/story/story.rs
@@ -9,6 +9,7 @@ use crate::{
     process::{get_fallback_choices, prepare_choices_for_user, process_buffer},
     story::{
         parse::read_story_content_from_string,
+        rng::StoryRng,
         types::{Choice, LineBuffer, Prompt},
         validate::validate_story_content,
     },
@@ -35,6 +36,8 @@ pub struct Story {
     selected_choice: Option<usize>,
     /// Whether or not the story has been started.
     in_progress: bool,
+    /// Random number generator, if needed.
+    rng: StoryRng,
 }
 
 impl Story {
@@ -631,6 +634,7 @@ pub fn read_story_from_string(string: &str) -> Result<Story, ReadError> {
         last_choices: None,
         selected_choice: None,
         in_progress: false,
+        rng: StoryRng::default(),
     })
 }
 

--- a/src/story/story.rs
+++ b/src/story/story.rs
@@ -36,8 +36,6 @@ pub struct Story {
     selected_choice: Option<usize>,
     /// Whether or not the story has been started.
     in_progress: bool,
-    /// Random number generator, if needed.
-    rng: StoryRng,
 }
 
 impl Story {
@@ -616,6 +614,7 @@ pub fn read_story_from_string(string: &str) -> Result<Story, ReadError> {
     let data = FollowData {
         knot_visit_counts: get_empty_knot_counts(&knots),
         variables,
+        rng: StoryRng::default(),
     };
 
     validate_story_content(&mut knots, &data)?;
@@ -634,7 +633,6 @@ pub fn read_story_from_string(string: &str) -> Result<Story, ReadError> {
         last_choices: None,
         selected_choice: None,
         in_progress: false,
-        rng: StoryRng::default(),
     })
 }
 
@@ -717,7 +715,7 @@ fn follow_knot(
 fn get_fallback_choice(
     choice_set: &[ChoiceInfo],
     current_address: &Address,
-    data: &FollowData,
+    data: &mut FollowData,
 ) -> Result<Choice, InklingError> {
     get_fallback_choices(choice_set, data).and_then(|choices| {
         choices.first().cloned().ok_or(InklingError::OutOfChoices {
@@ -752,6 +750,7 @@ mod tests {
         FollowData {
             knot_visit_counts: get_empty_knot_counts(knots),
             variables: HashMap::new(),
+            rng: StoryRng::default(),
         }
     }
 

--- a/src/story/validate/validate.rs
+++ b/src/story/validate/validate.rs
@@ -4,7 +4,7 @@ use crate::{
     error::{parse::validate::ValidationError, utils::MetaData},
     follow::FollowData,
     knot::{get_empty_knot_counts, Address, AddressKind, KnotSet},
-    story::{types::VariableSet, validate::namespace::validate_story_name_spaces},
+    story::{rng::StoryRng, types::VariableSet, validate::namespace::validate_story_name_spaces},
 };
 
 use std::collections::HashMap;
@@ -70,6 +70,7 @@ impl ValidationData {
         let follow_data = FollowData {
             knot_visit_counts: get_empty_knot_counts(knots),
             variables: variables.clone(),
+            rng: StoryRng::default(),
         };
 
         ValidationData {
@@ -231,6 +232,7 @@ pub(super) mod tests {
         let data = FollowData {
             knot_visit_counts: get_empty_knot_counts(&knots),
             variables,
+            rng: StoryRng::default(),
         };
 
         (knots, data)


### PR DESCRIPTION
Add optional support for shuffle sequences, using `rand` and `rand_chacha` as generators.